### PR TITLE
add contour map section

### DIFF
--- a/2021-05-28-terrainr-workshop.Rmd
+++ b/2021-05-28-terrainr-workshop.Rmd
@@ -297,14 +297,14 @@ names(contour_df) <- c("x", "y", "z", "r", "g", "b", "a") # longitude, latitude,
 contour_lines <- contour_df[contour_df$a != 0, ]
 
 ## plot it!
-ggplot(data=contour_lines)+
+ggplot(data = contour_lines)+
   geom_raster(mapping = aes(x, y, fill = z))+
   theme_void()+
   theme(plot.background = element_rect(fill="black"),
         plot.title = element_text(color="white"),
         legend.position = "none")+
-  coord_equal()+
-  scale_fill_scico(palette="hawaii", direction = -1)+
+  coord_sf(crs = 4326)+
+  scale_fill_scico(palette="imola", direction = 1)+
   ggtitle(paste("Half dome", site$lat, site$lng))
 
 ```
@@ -344,14 +344,40 @@ merge_co <- terrainr::merge_rasters(site_tiles_1$contours,
 
 ## On your own  
 
-Use the dataframe below to pull new starting coordinates and recreate the map. Share what you made in the chat!
+Use the dataframe below to pull new starting coordinates and recreate the map in a new location, with new layer, or maybe a new color palette. Share what you made in the chat!
 
 ```{r}
-## put a dataframe with coordinates here, where each row has the coordinates for a different site. Will add a random row sampler so people are getting different results. 
+# dataframe of cool places in the US
+places <- structure(list(ï..name = c("half dome", "moki dugway", "badwater basin", 
+"mount whitney", "monument valley navajo tribal park", "devil's lake", 
+"cadillac mountain", "mcafee knob", "sleeping bear dunes ", "grand canyon", 
+"miguel's pizza at red river gorge", "between cumberland and blue ridge mountains", 
+"missouri river floodplain and bluff", "shawangunk mountains", 
+"lake winnipesaukee, new hampshire", "mount washington, new hampshire", 
+"gravity hill, pa", "orcas island", "grand canyon of yellowstone", 
+"mauna loa", "tetons", "rocky mountain biological station"), 
+    lat = c(37.746036, 37.302306, 36.250278, 36.578581, 36.983333, 
+    43.420033, 44.35127, 37.392487, 44.878727, 36.2388, 37.783004, 
+    37.1177098, 38.568762, 41.72469, 43.606096, 44.270504, 40.153283, 
+    48.654167, 44.895556, 19.479444, 43.75, 38.958611), lng = c(-119.53294, 
+    -109.968944, -116.825833, -118.291995, -110.100411, -89.737405, 
+    -68.22649, -80.036298, -86.066458, -112.350427, -83.682861, 
+    -81.132816, -90.883408, -74.204946, -71.338624, -71.303115, 
+    -76.839954, -122.938333, -110.389444, -155.602778, -110.833333, 
+    -106.987778)), class = "data.frame", row.names = c(NA, -22L
+))
 
+# randomly pick one row from the dataframe
+site <- places[sample(nrow(places), 1), ]
+
+# convert to sf object and assign coordinate reference system 
+site_sf <- st_as_sf(site, coords = c("lng","lat"), crs = 4326)
+
+# buffer around point
+site_bbox <- set_bbox_side_length(site_sf, 10, "km")
+
+# keep going!
 ```
-
-
 
 
 # Part 4: Unity

--- a/2021-05-28-terrainr-workshop.Rmd
+++ b/2021-05-28-terrainr-workshop.Rmd
@@ -23,6 +23,7 @@ This chunk will install any missing packages, and then load them all:
 if (!require("sf")) install.packages("sf")
 if (!require("terrainr")) install.packages("terrainr")
 if (!require("ggplot2")) install.packages("ggplot2")
+if (!require("scico")) install.packages("scico")
 if (!require("raster")) install.packages("raster")
 if (!require("progressr")) install.packages("progressr")
 if (!require("progress")) install.packages("progress")
@@ -30,6 +31,7 @@ if (!require("progress")) install.packages("progress")
 library("sf")
 library("terrainr")
 library("ggplot2")
+library("scico")
 library("raster")
 library("progressr")
 handlers("progress")
@@ -232,6 +234,97 @@ plotRGB(campsites_ortho)
 This process is particularly useful for combining multiple map tiles from the 
 National Map into a single basemap, allowing you to overlay roads, rivers, and 
 more on orthoimagery.
+
+## Example 
+
+Now that we've seen a basic workflow using terrainr to pull layers from the National Map and plot with ggplot2, let's have some fun with it! Starting with the latitude and longitude coordinates for a new site, we'll create an sf object and add a spatial buffer around it like before.
+
+```{r}
+# yosemite NP
+site <- data.frame(lat = 37.7456, lng = -119.5521)
+
+# convert to sf object and assign coordinate reference system 
+site_sf <- st_as_sf(site, coords = c("lng","lat"), crs = 4326)
+
+# buffer around point
+site_bbox <- set_bbox_side_length(site_sf, 10, "km")
+```
+
+Now, to pull some data using terrainr. In the previous example we looked at elevation and orthoimagery. Other supported services are: nhd, govunits, contours, geonames, NHDPlus_HR, structures, transportation, and wbd. More info here: https://docs.ropensci.org/terrainr/#available-datasets
+
+Let's try elevation and contours this time
+
+```{r}
+with_progress(
+  site_tiles <- get_tiles(site_bbox, 
+                            output_prefix = "yosemite_np_10m",
+                            services = c("elevation", "contours"),
+                            resolution = 5)
+)
+
+site_tiles
+```
+
+Now we can convert the elevation and contour layers to plot with ggplot2. The contours layer is an RGBA multi-band raster layer, similar to the orthoimagery. RGBA has 4 channels: red, green, blue, and alpha. Alpha is like opacity
+
+```{r}
+elev <- raster(site_tiles$elevation)
+contours <- stack(site_tiles$contours)
+
+# look at structure of contours raster - has 4 layers
+contours
+```
+
+
+
+```{r}
+ggplot() + 
+  geom_spatial_rgb(data = contours,
+                   mapping = aes(x, y, r = red, g = green, b = blue)) + 
+  coord_sf(crs = 4326) + 
+  theme_void()
+```
+
+For the purposes of the workshop, we're avoiding large downloads. But if we were to increase the resolution even more, say to 1m, terrainr might break up the focal region into multiple tiles:
+
+```{r, eval = FALSE}
+## warning: running this code chunk will take over 5 minutes to complete
+with_progress(
+  site_tiles_1 <- get_tiles(site_bbox, 
+                            output_prefix = "yosemite_np_10m",
+                            services = c("elevation", "contours"),
+                            resolution = 1)
+)
+
+site_tiles_1
+
+```
+
+
+
+
+The scico package (https://github.com/thomasp85/scico) offers a selection of color palettes developed for scientific applications. They are perceptually uniform to represent data fairly, and universally readable by both color-vision deficient and color-blind people. 
+
+```{r}
+library(scico)
+
+scico_palette_show()
+
+```
+
+
+
+## On your own  
+
+
+
+```{r}
+
+
+```
+
+
+
 
 # Part 4: Unity
 

--- a/2021-05-28-terrainr-workshop.Rmd
+++ b/2021-05-28-terrainr-workshop.Rmd
@@ -257,7 +257,7 @@ Let's try elevation and contours this time
 ```{r}
 with_progress(
   site_tiles <- get_tiles(site_bbox, 
-                            output_prefix = "yosemite_np_10m",
+                            output_prefix = "yosemite_np_5m",
                             services = c("elevation", "contours"),
                             resolution = 5)
 )
@@ -265,17 +265,17 @@ with_progress(
 site_tiles
 ```
 
-Now we can convert the elevation and contour layers to plot with ggplot2. The contours layer is an RGBA multi-band raster layer, similar to the orthoimagery. RGBA has 4 channels: red, green, blue, and alpha. Alpha is like opacity
+Now we can convert the elevation and contour layers to plot with ggplot2. The contours layer is an RGBA multi-band raster layer, similar to the orthoimagery. 
 
 ```{r}
-elev <- raster(site_tiles$elevation)
+elevation <- raster(site_tiles$elevation)
 contours <- stack(site_tiles$contours)
 
 # look at structure of contours raster - has 4 layers
 contours
 ```
 
-
+RGBA has 4 channels: red, green, blue, and alpha. The 4th channel, alpha, is like opacity. In this case, alpha is 0 in cells without contour lines and 1 where contours exist.
 
 ```{r}
 ggplot() + 
@@ -283,6 +283,37 @@ ggplot() +
                    mapping = aes(x, y, r = red, g = green, b = blue)) + 
   coord_sf(crs = 4326) + 
   theme_void()
+``` 
+
+Contours reflect elevation, so let's make it so! The next chunk stacks elevation and contours together and coverts to a dataframe to plot using `geom_raster` with ggplot2. Then, using the alpha channel, the dataframe is filtered to just the contour lines, and elevation values are used in the color scale.
+
+
+```{r}
+contour_stack <- stack(elevation, contours)
+contour_df <- as.data.frame(contour_stack, xy = TRUE)
+
+names(contour_df) <- c("x", "y", "z", "r", "g", "b", "a") # longitude, latitude, elevation, red, green, blue, alpha
+
+contour_lines <- contour_df[contour_df$a != 0, ]
+
+## plot it!
+ggplot(data=contour_lines)+
+  geom_raster(mapping = aes(x, y, fill = z))+
+  theme_void()+
+  theme(plot.background = element_rect(fill="black"),
+        plot.title = element_text(color="white"),
+        legend.position = "none")+
+  coord_equal()+
+  scale_fill_scico(palette="hawaii", direction = -1)+
+  ggtitle(paste("Half dome", site$lat, site$lng))
+
+```
+
+
+This chart uses the scico package for color scale. Scico (https://github.com/thomasp85/scico) offers a selection of color palettes developed for scientific applications. They are perceptually uniform to represent data fairly, and universally readable by both color-vision deficient and color-blind people. 
+
+```{r}
+scico_palette_show() # to see all palette options
 ```
 
 For the purposes of the workshop, we're avoiding large downloads. But if we were to increase the resolution even more, say to 1m, terrainr might break up the focal region into multiple tiles:
@@ -300,26 +331,23 @@ site_tiles_1
 
 ```
 
-
-
-
-The scico package (https://github.com/thomasp85/scico) offers a selection of color palettes developed for scientific applications. They are perceptually uniform to represent data fairly, and universally readable by both color-vision deficient and color-blind people. 
-
+In which case they can be merged together using `merge_rasters`  
 ```{r}
-library(scico)
+merge_el <- terrainr::merge_rasters(site_tiles_1$elevation, 
+                          tempfile(fileext = ".tif"))
 
-scico_palette_show()
-
+merge_co <- terrainr::merge_rasters(site_tiles_1$contours, 
+                          tempfile(fileext = ".tif"))
 ```
 
 
 
 ## On your own  
 
-
+Use the dataframe below to pull new starting coordinates and recreate the map. Share what you made in the chat!
 
 ```{r}
-
+## put a dataframe with coordinates here, where each row has the coordinates for a different site. Will add a random row sampler so people are getting different results. 
 
 ```
 


### PR DESCRIPTION
Initial contributions for another ggplot map exercise. I ended up going a different direction than expected. 

The exercise recreates the same workflow demonstrated previously, but using the elevation and contour APIs. Then I am simply stacking the two, and using the contour alpha channel as a mask for elevation, and using the `scico` library to add a color scale. Then would like to add a data frame with other site coordinates, and encourage participants to try it on their own and share the result. I am building that coordinate list and will enter later. If time seems tight, this part could be skipped to keep moving.

Would love any feedback on this.